### PR TITLE
account split support

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1470,10 +1470,9 @@ fn do_process_ether_deploy(
 
     let make_write_instruction = |offset: u32, bytes: Vec<u8>| -> Instruction {
         use solana_sdk::instruction::AccountMeta;
-        let data_len: u64 = bytes.len().try_into().unwrap();
         Instruction::new(
             *loader_id,
-            &(100u8, offset, data_len, bytes.as_slice()),
+            &(100u8, offset, bytes.as_slice()),
             vec![AccountMeta::new(program_id, false),
                  AccountMeta::new(program_code, false),
                  AccountMeta::new(creator.pubkey(), true)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1448,11 +1448,11 @@ fn do_process_ether_deploy(
 
     println!("Create code account: {}", &program_code.to_string());
 
-    let make_create_account_instruction = |acc: &Pubkey, ether: &H160, nonce: u8, balance: u64, data_size: u64| {
+    let make_create_account_instruction = |acc: &Pubkey, ether: &H160, nonce: u8, balance: u64| {
         use solana_sdk::instruction::AccountMeta;
         Instruction::new(
             *loader_id,
-            &(22u32, balance, data_size, ether.as_fixed_bytes(), nonce),
+            &(22u32, balance, 97u64, ether.as_fixed_bytes(), nonce),
             vec![AccountMeta::new(creator.pubkey(), true),
                  AccountMeta::new(*acc, false),
                  AccountMeta::new(program_code, false),
@@ -1520,7 +1520,7 @@ fn do_process_ether_deploy(
                 program_data_len as u64,
                 &loader_id,
             )],*/
-        instructions.push(make_create_account_instruction(&program_id, &ether, nonce, minimum_balance, program_data_len as u64));
+        instructions.push(make_create_account_instruction(&program_id, &ether, nonce, minimum_balance));
         (instructions, minimum_balance)
     };
 
@@ -1572,7 +1572,7 @@ fn do_process_ether_deploy(
 
     {  // Create code account
         trace!("Create code account");
-        let make_code_account_instruction = system_instruction::create_account_with_seed(&creator.pubkey(), &program_code, &creator.pubkey(), &program_seed, 10000000, 1024*1024, loader_id);
+        let make_code_account_instruction = system_instruction::create_account_with_seed(&creator.pubkey(), &program_code, &creator.pubkey(), &program_seed, 10000000, program_data_len as u64, loader_id);
         let make_code_account_message = Message::new(&[make_code_account_instruction], Some(&creator.pubkey()));
         let mut program_code_transaction = Transaction::new_unsigned(make_code_account_message);
         program_code_transaction.try_sign(&signers, blockhash)?;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1521,6 +1521,7 @@ fn do_process_ether_deploy(
                 program_data_len as u64,
                 &loader_id,
             )],*/
+        instructions.push(system_instruction::create_account_with_seed(&creator.pubkey(), &program_code, &creator.pubkey(), &program_seed, minimum_balance_code, program_code_len as u64, loader_id));
         instructions.push(make_create_account_instruction(&program_id, &ether, nonce, minimum_balance_program));
         instructions
     };
@@ -1566,22 +1567,6 @@ fn do_process_ether_deploy(
         &messages,
         config.commitment,
     )?;
-
-    {  // Create code account
-        trace!("Create code account");
-        let make_code_account_instruction = system_instruction::create_account_with_seed(&creator.pubkey(), &program_code, &creator.pubkey(), &program_seed, minimum_balance_code, program_code_len as u64, loader_id);
-        let make_code_account_message = Message::new(&[make_code_account_instruction], Some(&creator.pubkey()));
-        let mut program_code_transaction = Transaction::new_unsigned(make_code_account_message);
-        program_code_transaction.try_sign(&signers, blockhash)?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-            &program_code_transaction,
-            config.commitment,
-            config.send_transaction_config,
-        );
-        log_instruction_custom_error::<SystemError>(result, &config).map_err(|err| {
-            CliError::DynamicProgramError(format!("Program code account allocation failed: {}", err))
-        })?;
-    }
 
     {  // Send initialize message
         trace!("Creating or modifying program account");

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1403,11 +1403,11 @@ fn do_process_ether_deploy(
     use std::convert::TryInto;
 
     let program_data = read_program_data(program_location)?;
-    let program_data_len = 97u64;
+    let program_data_len = 97;
     let program_code_len = 32 + program_data.len() + 2*1024;
-    let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len.try_into().unwrap())?;
+    let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
     let minimum_balance_code = rpc_client.get_minimum_balance_for_rent_exemption(program_code_len)?;
-    let minimum_caller_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len.try_into().unwrap())?;
+    let minimum_caller_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
 
     let creator = config.signers[0];
     let signers = [creator];
@@ -1452,7 +1452,7 @@ fn do_process_ether_deploy(
         use solana_sdk::instruction::AccountMeta;
         Instruction::new(
             *loader_id,
-            &(22u32, balance, program_data_len, ether.as_fixed_bytes(), nonce),
+            &(22u32, balance, 0 as u64, ether.as_fixed_bytes(), nonce),
             vec![AccountMeta::new(creator.pubkey(), true),
                  AccountMeta::new(*acc, false),
                  AccountMeta::new(program_code, false),
@@ -1473,7 +1473,7 @@ fn do_process_ether_deploy(
         let data_len: u64 = bytes.len().try_into().unwrap();
         Instruction::new(
             *loader_id,
-            &(100u32, offset, data_len, bytes.as_slice()),
+            &(100u8, offset, data_len, bytes.as_slice()),
             vec![AccountMeta::new(program_id, false),
                  AccountMeta::new(program_code, false),
                  AccountMeta::new(creator.pubkey(), true)]
@@ -1526,10 +1526,7 @@ fn do_process_ether_deploy(
     let balance_needed = minimum_balance_program + minimum_balance_code;
     println!("Minimum balance: {}", balance_needed);
 
-    println!("Initialize instructions: {:x?}", initial_instructions);
-    
-    // let program_code_instruction = make_create_code_account_instruction(&program_code, &ether, prog_nonce, minimum_balance, program_data_len as u64);
-    // let program_code_message = Message::new(&[program_code_instruction], Some(&config.signers[0].pubkey()));   
+    println!("Initialize instructions: {:x?}", initial_instructions);  
 
     let initial_message = Message::new(&initial_instructions, Some(&config.signers[0].pubkey()));
     let mut messages: Vec<&Message> = Vec::new();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1437,10 +1437,7 @@ fn do_process_ether_deploy(
     println!("Create account: {} with {} {}", program_id, ether, nonce);  
 
     let (program_code, program_seed) = {
-        let ether_string = hex::encode(ether.as_bytes());
-        let mut seed: String = ether_string[..14].to_string();
-        seed.push_str(&ether_string[40-14..]);
-        seed.push_str(&"code".to_string());
+        let seed = bs58::encode(&ether.to_fixed_bytes()).into_string();
         println!("Code account seed {} and len {}", &seed, &seed.len());
         let address = Pubkey::create_with_seed(&creator.pubkey(), &seed, loader_id).unwrap();
         (address, seed)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1469,11 +1469,11 @@ fn do_process_ether_deploy(
     };*/
 
     let make_write_instruction = |offset: u32, bytes: Vec<u8>| -> Instruction {
-        use loader_instruction::LoaderInstruction;
         use solana_sdk::instruction::AccountMeta;
+        let data_len: u64 = bytes.len().try_into().unwrap();
         Instruction::new(
             *loader_id,
-            &LoaderInstruction::Write {offset, bytes},
+            &(100u32, offset, data_len, bytes.as_slice()),
             vec![AccountMeta::new(program_id, false),
                  AccountMeta::new(program_code, false),
                  AccountMeta::new(creator.pubkey(), true)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1403,7 +1403,7 @@ fn do_process_ether_deploy(
     use std::convert::TryInto;
 
     let program_data = read_program_data(program_location)?;
-    let program_data_len = 97;
+    let program_data_len = 1+20+1+8+32+32;
     let program_code_len = 32 + program_data.len() + 2*1024;
     let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
     let minimum_balance_code = rpc_client.get_minimum_balance_for_rent_exemption(program_code_len)?;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1400,13 +1400,14 @@ fn do_process_ether_deploy(
 ) -> ProcessResult {
     use sha3::{Keccak256, Digest};
     use primitive_types::{H160, H256};
+    use std::convert::TryInto;
 
     let program_data = read_program_data(program_location)?;
     let program_data_len = 97u64;
     let program_code_len = 32 + program_data.len() + 2*1024;
-    let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
+    let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len.try_into().unwrap())?;
     let minimum_balance_code = rpc_client.get_minimum_balance_for_rent_exemption(program_code_len)?;
-    let minimum_caller_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
+    let minimum_caller_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len.try_into().unwrap())?;
 
     let creator = config.signers[0];
     let signers = [creator];

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1452,7 +1452,7 @@ fn do_process_ether_deploy(
         use solana_sdk::instruction::AccountMeta;
         Instruction::new(
             *loader_id,
-            &(22u32, balance, 0 as u64, ether.as_fixed_bytes(), nonce),
+            &(2u32, balance, 0 as u64, ether.as_fixed_bytes(), nonce),
             vec![AccountMeta::new(creator.pubkey(), true),
                  AccountMeta::new(*acc, false),
                  AccountMeta::new(program_code, false),
@@ -1469,12 +1469,12 @@ fn do_process_ether_deploy(
     };*/
 
     let make_write_instruction = |offset: u32, bytes: Vec<u8>| -> Instruction {
+        use loader_instruction::LoaderInstruction;
         use solana_sdk::instruction::AccountMeta;
         Instruction::new(
             *loader_id,
-            &(100u8, offset, bytes.as_slice()),
-            vec![AccountMeta::new(program_id, false),
-                 AccountMeta::new(program_code, false),
+            &LoaderInstruction::Write {offset, bytes},
+            vec![AccountMeta::new(program_code, false),
                  AccountMeta::new(creator.pubkey(), true)]
         )
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1402,12 +1402,14 @@ fn do_process_ether_deploy(
     use primitive_types::{H160, H256};
     use std::convert::TryInto;
 
+    let ACCOUNT_HEADER_SIZE = 1+20+1+8+32+32;
+    let CONTRACT_HEADER_SIZE = 1+32+4;
+
     let program_data = read_program_data(program_location)?;
-    let program_data_len = 1+20+1+8+32+32;
-    let program_code_len = 32 + program_data.len() + 2*1024;
-    let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
+    let program_code_len = CONTRACT_HEADER_SIZE + program_data.len() + 2*1024;
+    let minimum_balance_program = rpc_client.get_minimum_balance_for_rent_exemption(ACCOUNT_HEADER_SIZE)?;
     let minimum_balance_code = rpc_client.get_minimum_balance_for_rent_exemption(program_code_len)?;
-    let minimum_caller_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data_len)?;
+    let minimum_caller_balance = rpc_client.get_minimum_balance_for_rent_exemption(ACCOUNT_HEADER_SIZE)?;
 
     let creator = config.signers[0];
     let signers = [creator];

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1531,10 +1531,7 @@ fn do_process_ether_deploy(
 
     let initial_message = Message::new(&initial_instructions, Some(&config.signers[0].pubkey()));
     let mut messages: Vec<&Message> = Vec::new();
-    // messages.push(&program_code_message);
     messages.push(&initial_message);
-    
-    // messages.push(&create_acc_message);
 
     let mut write_messages = vec![];
 


### PR DESCRIPTION
## Add support for splitting ethereum contract account to account and code accounts to solana cli.
Adds contract address and account creation.
Adds contract account to ethereum account creation, write and finalize instructions.
Return Contract account id in result.
Minor related changes.

### Depends on:

Cyber-Core/solana-program-library#108