### PR TITLE
#29 Added alt_bn256 syscalls

### DIFF
--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "rust/128bit",
     "rust/128bit_dep",
     "rust/alloc",
+    "rust/alt_bn128",
     "rust/call_depth",
     "rust/caller_access",
     "rust/custom_heap",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -60,6 +60,7 @@ fn main() {
         let rust_programs = [
             "128bit",
             "alloc",
+            "alt_bn128",
             "call_depth",
             "caller_access",
             "custom_heap",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.3.1"
+bn-plus = "=0.4"
 byteorder = "1.3.4"
 log = "0.4.11"
 num-derive = "0.3"

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -165,25 +165,28 @@ pub fn register_syscalls(
         syscall_registry.register_syscall_by_name(b"sol_memset_", SyscallMemset::call)?;
     }
 
+    // TODO: This feature ID is not registered now. So we will enabled it in any case for tests purposes.
     // alt_bn128_addition
-    if invoke_context.is_feature_active(&alt_bn128_addition_syscall_enabled::id()) {
+    //if invoke_context.is_feature_active(&alt_bn128_addition_syscall_enabled::id()) {
         syscall_registry
             .register_syscall_by_name(b"sol_alt_bn128_addition", SyscallAltBn128Addition::call)?;
-    }
+    //}
 
+    // TODO: This feature ID is not registered now. So we will enabled it in any case for tests purposes.
     // alt_bn128_multiplication
-    if invoke_context.is_feature_active(&alt_bn128_multiplication_syscall_enabled::id()) {
+    // if invoke_context.is_feature_active(&alt_bn128_multiplication_syscall_enabled::id()) {
         syscall_registry.register_syscall_by_name(
             b"sol_alt_bn128_multiplication",
             SyscallAltBn128Multiplication::call,
         )?;
-    }
+    //}
 
+    // TODO: This feature ID is not registered now. So we will enabled it in any case for tests purposes.
     // alt_bn128_pairing
-    if invoke_context.is_feature_active(&alt_bn128_pairing_syscall_enabled::id()) {
+    // if invoke_context.is_feature_active(&alt_bn128_pairing_syscall_enabled::id()) {
         syscall_registry
             .register_syscall_by_name(b"sol_alt_bn128_pairing", SyscallAltBn128Pairing::call)?;
-    }
+    // }
 
     // Cross-program invocation syscalls
     syscall_registry

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -479,7 +479,7 @@ uint64_t sol_alt_bn128_addition(
  * @param result 64 byte array to hold the result. ...
  * @return 0 if executed successfully
  */
-uint64_t sol_alt_bn128_addition(
+uint64_t sol_alt_bn128_multiplication(
     const uint8_t *input,
     const unit64_t input_size,
     uint8_t *result
@@ -493,7 +493,7 @@ uint64_t sol_alt_bn128_addition(
  * @param result 64 byte array to hold the result. ...
  * @return 0 if executed successfully
  */
-uint64_t sol_alt_bn128_addition(
+uint64_t sol_alt_bn128_pairing(
     const uint8_t *input,
     const unit64_t input_size,
     uint8_t *result

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -457,6 +457,47 @@ uint64_t sol_keccak256(
     uint8_t *result
 );
 
+/**
+ * Addition on elliptic curves alt_bn128
+ *
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+uint64_t sol_alt_bn128_addition(
+    const uint8_t *input,
+    const unit64_t input_size,
+    uint8_t *result
+);
+
+/**
+ * Multiplication on elliptic curves alt_bn128
+ *
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+uint64_t sol_alt_bn128_addition(
+    const uint8_t *input,
+    const unit64_t input_size,
+    uint8_t *result
+);
+
+/**
+ * Pairing on elliptic curves alt_bn128
+ *
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+uint64_t sol_alt_bn128_addition(
+    const uint8_t *input,
+    const unit64_t input_size,
+    uint8_t *result
+);
 
 /** Length of a secp256k1 recover input hash */
 #define SECP256K1_RECOVER_HASH_LENGTH 32

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -34,14 +34,18 @@ solana-sdk-macro = { path = "../macro", version = "=1.7.9" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_arch = "bpf"))'.dependencies]
+array-bytes = "=1.4.1"
+bn-plus = "=0.4"
 blake3 = "0.3.7"
 curve25519-dalek = "2.1.0"
+etcommon-bigint = "=0.2.10"
+itertools = "0.9.0"
 libsecp256k1 = "0.5.0"
 rand = "0.7.0"
 solana-logger = { path = "../../logger", version = "=1.7.9" }
+static_assertions = "1.1.0"
 
 [dev-dependencies]
-static_assertions = "1.1.0"
 assert_matches = "1.3.0"
 bincode = "1.3.1"
 serde_json = "1.0.56"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -32,6 +32,7 @@ solana-frozen-abi = { path = "../../frozen-abi", version = "=1.7.9" }
 solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.7.9" }
 solana-sdk-macro = { path = "../macro", version = "=1.7.9" }
 thiserror = "1.0"
+static_assertions = "1.1.0"
 
 [target.'cfg(not(target_arch = "bpf"))'.dependencies]
 array-bytes = "=1.4.1"
@@ -43,7 +44,6 @@ itertools = "0.9.0"
 libsecp256k1 = "0.5.0"
 rand = "0.7.0"
 solana-logger = { path = "../../logger", version = "=1.7.9" }
-static_assertions = "1.1.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/sdk/program/src/alt_bn128.rs
+++ b/sdk/program/src/alt_bn128.rs
@@ -1,0 +1,824 @@
+pub mod prelude {
+    pub use crate::alt_bn128::{
+        alt_bn128_addition, alt_bn128_multiplication, alt_bn128_pairing, consts::*, AltBn128Error,
+    };
+}
+
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    core::convert::TryFrom,
+    thiserror::Error,
+};
+
+#[cfg(not(target_arch = "bpf"))]
+use {
+    bigint::U256,
+    bn::{pairing, AffineG1, AffineG2, Fq, Fq2, Fr, Group, Gt, G1, G2},
+    consts::*,
+};
+
+//---- Constants
+
+mod consts {
+    use static_assertions::const_assert_eq;
+
+    /// Input length for the add operation.
+    pub const ALT_BN128_ADDITION_INPUT_LEN: usize = 128;
+
+    /// Input length for the multiplication operation.
+    pub const ALT_BN128_MULTIPLICATION_INPUT_LEN: usize = 128;
+
+    /// Pair element length.
+    pub const ALT_BN128_PAIRING_ELEMENT_LEN: usize = 192;
+
+    /// Output length for the add operation.
+    pub const ALT_BN128_ADDITION_OUTPUT_LEN: usize = 64;
+
+    /// Output length for the multiplication operation.
+    pub const ALT_BN128_MULTIPLICATION_OUTPUT_LEN: usize = 64;
+
+    /// Output length for pairing operation..
+    pub const ALT_BN128_PAIRING_OUTPUT_LEN: usize = 32;
+
+    /// Size of the EC point field, in bytes.
+    pub const ALT_BN128_FIELD_SIZE: usize = 32;
+
+    /// Size of the EC point. `alt_bn128` point contains
+    /// the consistently united x and y fields as 64 bytes.
+    pub const ALT_BN128_POINT_SIZE: usize = 64;
+
+    // COMPIlE TIME TEST: the length of a point must be twice the length of the field.
+    #[cfg(not(target_arch = "bpf"))]
+    const_assert_eq!(ALT_BN128_POINT_SIZE, ALT_BN128_FIELD_SIZE * 2);
+
+    /// Internal representation of the EC field (32 bytes).
+    pub(super) type FieldBytes = [u8; ALT_BN128_FIELD_SIZE];
+
+    /// Internal representation of the EC point (64 bytes).
+    pub(super) type PointBytes = [u8; ALT_BN128_POINT_SIZE];
+}
+
+//---- Custom errors
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum AltBn128Error {
+    #[error("The input data is invalid")]
+    InvalidInputData,
+    #[error("Incorrect size of input data slice for curve field")]
+    InvalidFieldSliceSize,
+    #[error("Incorrect size of input data slice for curve point")]
+    InvalidPointSliceSize,
+    #[error("Slice data is going out of input data bounds")]
+    SliceOutOfBounds,
+    #[error("Cannot convert slice to specified array")]
+    TryFromSliceError,
+    #[error("Invalid field data")]
+    FieldError,
+    #[error("Invalid group data")]
+    GroupError,
+    #[error("Unexpected error")]
+    UnexpectedError,
+}
+
+impl From<u64> for AltBn128Error {
+    fn from(v: u64) -> AltBn128Error {
+        match v {
+            1 => AltBn128Error::InvalidInputData,
+            2 => AltBn128Error::InvalidFieldSliceSize,
+            3 => AltBn128Error::InvalidPointSliceSize,
+            4 => AltBn128Error::SliceOutOfBounds,
+            5 => AltBn128Error::TryFromSliceError,
+            6 => AltBn128Error::FieldError,
+            7 => AltBn128Error::GroupError,
+            _ => AltBn128Error::UnexpectedError,
+        }
+    }
+}
+
+impl From<AltBn128Error> for u64 {
+    fn from(v: AltBn128Error) -> u64 {
+        match v {
+            AltBn128Error::InvalidInputData => 1,
+            AltBn128Error::InvalidFieldSliceSize => 2,
+            AltBn128Error::InvalidPointSliceSize => 3,
+            AltBn128Error::SliceOutOfBounds => 4,
+            AltBn128Error::TryFromSliceError => 5,
+            AltBn128Error::FieldError => 6,
+            AltBn128Error::GroupError => 7,
+            AltBn128Error::UnexpectedError => 0,
+        }
+    }
+}
+
+//---- Field & Point structs
+
+/// Field struct.
+#[repr(transparent)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    AbiExample,
+)]
+pub struct AltBn128Field(FieldBytes);
+
+impl AltBn128Field {
+    pub fn to_bytes(self) -> FieldBytes {
+        self.0
+    }
+}
+
+impl From<FieldBytes> for AltBn128Field {
+    fn from(input: FieldBytes) -> Self {
+        Self(input)
+    }
+}
+
+impl TryFrom<&[u8]> for AltBn128Field {
+    type Error = AltBn128Error;
+    fn try_from(input: &[u8]) -> Result<Self, Self::Error> {
+        FieldBytes::try_from(input)
+            .map_err(|_| AltBn128Error::TryFromSliceError)
+            .map(Self)
+    }
+}
+
+impl TryFrom<(&[u8], usize)> for AltBn128Field {
+    type Error = AltBn128Error;
+    fn try_from((input, pos): (&[u8], usize)) -> Result<Self, Self::Error> {
+        if input.len() < pos + ALT_BN128_FIELD_SIZE {
+            return Err(AltBn128Error::SliceOutOfBounds);
+        }
+        let mut buf = [0; ALT_BN128_FIELD_SIZE];
+        buf.copy_from_slice(&input[pos..(pos + ALT_BN128_FIELD_SIZE)]);
+        Ok(AltBn128Field::from(buf))
+    }
+}
+
+/// Point struct.
+#[repr(transparent)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    AbiExample,
+)]
+pub struct AltBn128Point((AltBn128Field, AltBn128Field));
+
+impl AltBn128Point {
+    pub fn new(x: AltBn128Field, y: AltBn128Field) -> Self {
+        Self((x, y))
+    }
+
+    pub fn x(self) -> AltBn128Field {
+        (self.0).0
+    }
+
+    pub fn y(self) -> AltBn128Field {
+        (self.0).1
+    }
+
+    pub fn to_bytes(self) -> Result<PointBytes, AltBn128Error> {
+        PointBytes::try_from(
+            [self.x().to_bytes(), self.y().to_bytes()]
+                .concat()
+                .as_slice(),
+        )
+        .map_err(|_| AltBn128Error::TryFromSliceError)
+    }
+}
+
+impl TryFrom<&[u8]> for AltBn128Point {
+    type Error = AltBn128Error;
+    fn try_from(input: &[u8]) -> Result<Self, Self::Error> {
+        AltBn128Point::try_from(
+            &PointBytes::try_from(input).map_err(|_| AltBn128Error::TryFromSliceError)?,
+        )
+    }
+}
+
+impl TryFrom<&PointBytes> for AltBn128Point {
+    type Error = AltBn128Error;
+    fn try_from(point_data: &PointBytes) -> Result<Self, Self::Error> {
+        Ok(AltBn128Point::new(
+            AltBn128Field::try_from((point_data as &[u8], 0))?,
+            AltBn128Field::try_from((point_data as &[u8], ALT_BN128_FIELD_SIZE))?,
+        ))
+    }
+}
+
+//----
+
+// Field -> Fq
+#[cfg(not(target_arch = "bpf"))]
+impl TryFrom<&AltBn128Field> for Fq {
+    type Error = AltBn128Error;
+    fn try_from(value: &AltBn128Field) -> Result<Self, Self::Error> {
+        Fq::from_slice(&value.0).map_err(|_| AltBn128Error::FieldError)
+    }
+}
+
+// Field -> Fr
+#[cfg(not(target_arch = "bpf"))]
+impl TryFrom<&AltBn128Field> for Fr {
+    type Error = AltBn128Error;
+    fn try_from(value: &AltBn128Field) -> Result<Self, Self::Error> {
+        Fr::from_slice(&value.0).map_err(|_| AltBn128Error::FieldError)
+    }
+}
+
+// FqPair
+#[cfg(not(target_arch = "bpf"))]
+struct FqPair(pub Fq, pub Fq);
+#[cfg(not(target_arch = "bpf"))]
+impl FqPair {
+    pub fn new(x: Fq, y: Fq) -> Self {
+        Self(x, y)
+    }
+}
+
+// (Fq, Fq) -> G1
+#[cfg(not(target_arch = "bpf"))]
+impl TryFrom<FqPair> for G1 {
+    type Error = AltBn128Error;
+    fn try_from(pair: FqPair) -> Result<Self, Self::Error> {
+        Ok(if pair.0 == Fq::zero() && pair.1 == Fq::zero() {
+            G1::zero()
+        } else {
+            G1::from(AffineG1::new(pair.0, pair.1).map_err(|_| AltBn128Error::GroupError)?)
+        })
+    }
+}
+
+// (Fq, Fq) -> Fq2
+#[cfg(not(target_arch = "bpf"))]
+impl From<FqPair> for Fq2 {
+    fn from(pair: FqPair) -> Self {
+        Fq2::new(pair.0, pair.1)
+    }
+}
+
+//---- Precompiled contracts
+
+pub fn alt_bn128_addition(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
+    #[cfg(target_arch = "bpf")]
+    {
+        extern "C" {
+            fn sol_alt_bn128_addition(input: *const u8, result: *mut u8) -> u64;
+        }
+
+        if input.len() > ALT_BN128_ADDITION_INPUT_LEN {
+            return Err(AltBn128Error::InvalidInputData);
+        }
+        let mut result_buffer = [0; ALT_BN128_ADDITION_OUTPUT_LEN];
+        let result = unsafe { sol_alt_bn128_addition(input.as_ptr(), result_buffer.as_mut_ptr()) };
+
+        match result {
+            0 => Ok(result_buffer.to_vec()),
+            error => Err(AltBn128Error::from(error)),
+        }
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        if input.len() > ALT_BN128_ADDITION_INPUT_LEN {
+            return Err(AltBn128Error::InvalidInputData);
+        }
+        let mut input = input.to_vec();
+        input.resize(ALT_BN128_ADDITION_INPUT_LEN, 0);
+
+        let px = &AltBn128Field::try_from((input.as_slice(), 0))?;
+        let py = &AltBn128Field::try_from((input.as_slice(), ALT_BN128_FIELD_SIZE))?;
+        let qx = &AltBn128Field::try_from((input.as_slice(), ALT_BN128_FIELD_SIZE * 2))?;
+        let qy = &AltBn128Field::try_from((input.as_slice(), ALT_BN128_FIELD_SIZE * 3))?;
+
+        let p = G1::try_from(FqPair::new(Fq::try_from(px)?, Fq::try_from(py)?))?;
+        let q = G1::try_from(FqPair::new(Fq::try_from(qx)?, Fq::try_from(qy)?))?;
+
+        let mut result_point_data = [0; ALT_BN128_ADDITION_OUTPUT_LEN];
+        if let Some(result_point) = AffineG1::from_jacobian(p + q) {
+            result_point
+                .x()
+                .to_big_endian(&mut result_point_data[0..ALT_BN128_FIELD_SIZE])
+                .map_err(|_| AltBn128Error::SliceOutOfBounds)?;
+            result_point
+                .y()
+                .to_big_endian(&mut result_point_data[ALT_BN128_FIELD_SIZE..])
+                .map_err(|_| AltBn128Error::SliceOutOfBounds)?;
+        }
+        Ok(result_point_data.to_vec())
+    }
+}
+
+pub fn alt_bn128_multiplication(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
+    #[cfg(target_arch = "bpf")]
+    {
+        extern "C" {
+            fn sol_alt_bn128_multiplication(input: *const u8, result: *mut u8) -> u64;
+        }
+
+        if input.len() > ALT_BN128_MULTIPLICATION_INPUT_LEN {
+            return Err(AltBn128Error::InvalidInputData);
+        }
+        let mut result_buffer = [0u8; ALT_BN128_POINT_SIZE];
+        let result =
+            unsafe { sol_alt_bn128_multiplication(input.as_ptr(), result_buffer.as_mut_ptr()) };
+
+        match result {
+            0 => Ok(result_buffer.to_vec()),
+            error => Err(AltBn128Error::from(error)),
+        }
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        if input.len() > ALT_BN128_MULTIPLICATION_INPUT_LEN {
+            return Err(AltBn128Error::InvalidInputData);
+        }
+        let mut input = input.to_vec();
+        input.resize(ALT_BN128_MULTIPLICATION_INPUT_LEN, 0);
+
+        let px = &AltBn128Field::try_from((input.as_slice(), 0))?;
+        let py = &AltBn128Field::try_from((input.as_slice(), ALT_BN128_FIELD_SIZE))?;
+        let fr = &AltBn128Field::try_from((input.as_slice(), ALT_BN128_FIELD_SIZE * 2))?;
+
+        let p = G1::try_from(FqPair::new(Fq::try_from(px)?, Fq::try_from(py)?))?;
+        let fr = Fr::try_from(fr)?;
+
+        let mut result_point_data = [0; ALT_BN128_MULTIPLICATION_OUTPUT_LEN];
+        if let Some(result_point) = AffineG1::from_jacobian(p * fr) {
+            result_point
+                .x()
+                .to_big_endian(&mut result_point_data[0..ALT_BN128_FIELD_SIZE])
+                .map_err(|_| AltBn128Error::SliceOutOfBounds)?;
+            result_point
+                .y()
+                .to_big_endian(&mut result_point_data[ALT_BN128_FIELD_SIZE..])
+                .map_err(|_| AltBn128Error::SliceOutOfBounds)?;
+        }
+        Ok(result_point_data.to_vec())
+    }
+}
+
+pub fn alt_bn128_pairing(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
+    #[cfg(target_arch = "bpf")]
+    {
+        extern "C" {
+            fn sol_alt_bn128_pairing(input: *const u8, result: *mut u8) -> u64;
+        }
+
+        if input.len() % consts::ALT_BN128_PAIRING_ELEMENT_LEN != 0 {
+            return Err(AltBn128Error::InvalidInputData);
+        }
+        let mut result_buffer = [0u8; 32];
+        let result = unsafe { sol_alt_bn128_pairing(input.as_ptr(), result_buffer.as_mut_ptr()) };
+
+        match result {
+            0 => Ok(result_buffer.to_vec()),
+            error => Err(AltBn128Error::from(error)),
+        }
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        if input.len() % consts::ALT_BN128_PAIRING_ELEMENT_LEN != 0 {
+            return Err(AltBn128Error::InvalidInputData);
+        }
+
+        fn read_one(s: &[u8]) -> Result<(G1, G2), AltBn128Error> {
+            let ax = Fq::try_from(&AltBn128Field::try_from((s, 0))?)?;
+            let ay = Fq::try_from(&AltBn128Field::try_from((s, ALT_BN128_FIELD_SIZE))?)?;
+            let bay = Fq::try_from(&AltBn128Field::try_from((s, ALT_BN128_FIELD_SIZE * 2))?)?;
+            let bax = Fq::try_from(&AltBn128Field::try_from((s, ALT_BN128_FIELD_SIZE * 3))?)?;
+            let bby = Fq::try_from(&AltBn128Field::try_from((s, ALT_BN128_FIELD_SIZE * 4))?)?;
+            let bbx = Fq::try_from(&AltBn128Field::try_from((s, ALT_BN128_FIELD_SIZE * 5))?)?;
+
+            let ba = Fq2::new(bax, bay);
+            let bb = Fq2::new(bbx, bby);
+
+            let b = if ba.is_zero() && bb.is_zero() {
+                G2::zero()
+            } else {
+                G2::from(AffineG2::new(ba, bb).map_err(|_| AltBn128Error::GroupError)?)
+            };
+            let a = G1::try_from(FqPair::new(ax, ay))?;
+            Ok((a, b))
+        }
+
+        let ele_len = input.len() / ALT_BN128_PAIRING_ELEMENT_LEN;
+        let mut acc = Gt::one();
+        for i in 0..ele_len {
+            let (a, b) = read_one(
+                &input[i * ALT_BN128_PAIRING_ELEMENT_LEN
+                    ..i * ALT_BN128_PAIRING_ELEMENT_LEN + ALT_BN128_PAIRING_ELEMENT_LEN],
+            )?;
+            acc = acc * pairing(a, b);
+        }
+
+        let result = if acc == Gt::one() {
+            U256::from(1)
+        } else {
+            U256::zero()
+        };
+
+        let mut output = vec![0u8; ALT_BN128_PAIRING_OUTPUT_LEN];
+        result.to_big_endian(&mut output);
+
+        Ok(output)
+    }
+}
+
+#[test]
+#[cfg(not(target_arch = "bpf"))]
+fn alt_bn128_addition_test() {
+    use serde::Deserialize;
+
+    let test_data = r#"[
+        {
+            "Input": "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f3726607c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
+            "Expected": "2243525c5efd4b9c3d3c45ac0ca3fe4dd85e830a4ce6b65fa1eeaee202839703301d1d33be6da8e509df21cc35964723180eed7532537db9ae5e7d48f195c915",
+            "Name": "chfast1",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "2243525c5efd4b9c3d3c45ac0ca3fe4dd85e830a4ce6b65fa1eeaee202839703301d1d33be6da8e509df21cc35964723180eed7532537db9ae5e7d48f195c91518b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+            "Expected": "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb721611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+            "Name": "chfast2",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "cdetrio1",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "cdetrio2",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "cdetrio3",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "cdetrio4",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "cdetrio5",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Name": "cdetrio6",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Name": "cdetrio7",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Name": "cdetrio8",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Gas": 150,
+            "Name": "cdetrio9",
+            "NoBenchmark": false
+        },{
+            "Input": "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Gas": 150,
+            "Name": "cdetrio10",
+            "NoBenchmark": false
+        },{
+            "Input": "0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+            "Expected": "030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd315ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4",
+            "Name": "cdetrio11",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd315ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4",
+            "Name": "cdetrio12",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d98",
+            "Expected": "15bf2bb17880144b5d1cd2b1f46eff9d617bffd1ca57c37fb5a49bd84e53cf66049c797f9ce0d17083deb32b5e36f2ea2a212ee036598dd7624c168993d1355f",
+            "Name": "cdetrio13",
+            "Gas": 150,
+            "NoBenchmark": false
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa92e83f8d734803fc370eba25ed1f6b8768bd6d83887b87165fc2434fe11a830cb00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Expected": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "cdetrio14",
+            "Gas": 150,
+            "NoBenchmark": false
+        }
+    ]"#;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
+    struct TestCase {
+        input: String,
+        expected: String,
+        name: String,
+    }
+
+    let test_cases: Vec<TestCase> = serde_json::from_str(test_data).unwrap();
+
+    test_cases.iter().for_each(|test| {
+        println!("Running test {}", &test.name);
+        let input = array_bytes::hex2bytes_unchecked(&test.input);
+        let result = alt_bn128_addition(&input);
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        let expected = array_bytes::hex2bytes_unchecked(&test.expected);
+        assert_eq!(result, expected);
+    });
+}
+
+#[test]
+#[cfg(not(target_arch = "bpf"))]
+fn alt_bn128_multiplication_test() {
+    use serde::Deserialize;
+
+    let test_data = r#"[
+        {
+            "Input": "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb721611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb20400000000000000000000000000000000000000000000000011138ce750fa15c2",
+            "Expected": "070a8d6a982153cae4be29d434e8faef8a47b274a053f5a4ee2a6c9c13c31e5c031b8ce914eba3a9ffb989f9cdd5b0f01943074bf4f0f315690ec3cec6981afc",
+            "Name": "chfast1",
+            "Gas": 6000,
+            "NoBenchmark": false
+        },{
+            "Input": "070a8d6a982153cae4be29d434e8faef8a47b274a053f5a4ee2a6c9c13c31e5c031b8ce914eba3a9ffb989f9cdd5b0f01943074bf4f0f315690ec3cec6981afc30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46",
+            "Expected": "025a6f4181d2b4ea8b724290ffb40156eb0adb514c688556eb79cdea0752c2bb2eff3f31dea215f1eb86023a133a996eb6300b44da664d64251d05381bb8a02e",
+            "Name": "chfast2",
+            "Gas": 6000,
+            "NoBenchmark": false
+        },{
+            "Input": "025a6f4181d2b4ea8b724290ffb40156eb0adb514c688556eb79cdea0752c2bb2eff3f31dea215f1eb86023a133a996eb6300b44da664d64251d05381bb8a02e183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea3",
+            "Expected": "14789d0d4a730b354403b5fac948113739e276c23e0258d8596ee72f9cd9d3230af18a63153e0ec25ff9f2951dd3fa90ed0197bfef6e2a1a62b5095b9d2b4a27",
+            "Name": "chfast3",
+            "Gas": 6000,
+            "NoBenchmark": false
+        },{
+            "Input": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe31a2f3c951f6dadcc7ee9007dff81504b0fcd6d7cf59996efdc33d92bf7f9f8f6ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "Expected": "2cde5879ba6f13c0b5aa4ef627f159a3347df9722efce88a9afbb20b763b4c411aa7e43076f6aee272755a7f9b84832e71559ba0d2e0b17d5f9f01755e5b0d11",
+            "Name": "cdetrio1",
+            "Gas": 6000,
+            "NoBenchmark": false
+        },{
+            "Input": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe31a2f3c951f6dadcc7ee9007dff81504b0fcd6d7cf59996efdc33d92bf7f9f8f630644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
+            "Expected": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe3163511ddc1c3f25d396745388200081287b3fd1472d8339d5fecb2eae0830451",
+            "Name": "cdetrio2",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe31a2f3c951f6dadcc7ee9007dff81504b0fcd6d7cf59996efdc33d92bf7f9f8f60000000000000000000000000000000100000000000000000000000000000000",
+            "Expected": "1051acb0700ec6d42a88215852d582efbaef31529b6fcbc3277b5c1b300f5cf0135b2394bb45ab04b8bd7611bd2dfe1de6a4e6e2ccea1ea1955f577cd66af85b",
+            "Name": "cdetrio3",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe31a2f3c951f6dadcc7ee9007dff81504b0fcd6d7cf59996efdc33d92bf7f9f8f60000000000000000000000000000000000000000000000000000000000000009",
+            "Expected": "1dbad7d39dbc56379f78fac1bca147dc8e66de1b9d183c7b167351bfe0aeab742cd757d51289cd8dbd0acf9e673ad67d0f0a89f912af47ed1be53664f5692575",
+            "Name": "cdetrio4",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe31a2f3c951f6dadcc7ee9007dff81504b0fcd6d7cf59996efdc33d92bf7f9f8f60000000000000000000000000000000000000000000000000000000000000001",
+            "Expected": "1a87b0584ce92f4593d161480614f2989035225609f08058ccfa3d0f940febe31a2f3c951f6dadcc7ee9007dff81504b0fcd6d7cf59996efdc33d92bf7f9f8f6",
+            "Name": "cdetrio5",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "Expected": "29e587aadd7c06722aabba753017c093f70ba7eb1f1c0104ec0564e7e3e21f6022b1143f6a41008e7755c71c3d00b6b915d386de21783ef590486d8afa8453b1",
+            "Name": "cdetrio6",
+            "Gas": 6000,
+            "NoBenchmark": false
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
+            "Expected": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa92e83f8d734803fc370eba25ed1f6b8768bd6d83887b87165fc2434fe11a830cb",
+            "Name": "cdetrio7",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c0000000000000000000000000000000100000000000000000000000000000000",
+            "Expected": "221a3577763877920d0d14a91cd59b9479f83b87a653bb41f82a3f6f120cea7c2752c7f64cdd7f0e494bff7b60419f242210f2026ed2ec70f89f78a4c56a1f15",
+            "Name": "cdetrio8",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c0000000000000000000000000000000000000000000000000000000000000009",
+            "Expected": "228e687a379ba154554040f8821f4e41ee2be287c201aa9c3bc02c9dd12f1e691e0fd6ee672d04cfd924ed8fdc7ba5f2d06c53c1edc30f65f2af5a5b97f0a76a",
+            "Name": "cdetrio9",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c0000000000000000000000000000000000000000000000000000000000000001",
+            "Expected": "17c139df0efee0f766bc0204762b774362e4ded88953a39ce849a8a7fa163fa901e0559bacb160664764a357af8a9fe70baa9258e0b959273ffc5718c6d4cc7c",
+            "Name": "cdetrio10",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d98ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "Expected": "00a1a234d08efaa2616607e31eca1980128b00b415c845ff25bba3afcb81dc00242077290ed33906aeb8e42fd98c41bcb9057ba03421af3f2d08cfc441186024",
+            "Name": "cdetrio11",
+            "Gas": 6000,
+            "NoBenchmark": false
+        },{
+            "Input": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d9830644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
+            "Expected": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b8692929ee761a352600f54921df9bf472e66217e7bb0cee9032e00acc86b3c8bfaf",
+            "Name": "cdetrio12",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d980000000000000000000000000000000100000000000000000000000000000000",
+            "Expected": "1071b63011e8c222c5a771dfa03c2e11aac9666dd097f2c620852c3951a4376a2f46fe2f73e1cf310a168d56baa5575a8319389d7bfa6b29ee2d908305791434",
+            "Name": "cdetrio13",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d980000000000000000000000000000000000000000000000000000000000000009",
+            "Expected": "19f75b9dd68c080a688774a6213f131e3052bd353a304a189d7a2ee367e3c2582612f545fb9fc89fde80fd81c68fc7dcb27fea5fc124eeda69433cf5c46d2d7f",
+            "Name": "cdetrio14",
+            "Gas": 6000,
+            "NoBenchmark": true
+        },{
+            "Input": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d980000000000000000000000000000000000000000000000000000000000000001",
+            "Expected": "039730ea8dff1254c0fee9c0ea777d29a9c710b7e616683f194f18c43b43b869073a5ffcc6fc7a28c30723d6e58ce577356982d65b833a5a5c15bf9024b43d98",
+            "Name": "cdetrio15",
+            "Gas": 6000,
+            "NoBenchmark": true
+        }
+    ]"#;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
+    struct TestCase {
+        input: String,
+        expected: String,
+        name: String,
+    }
+
+    let test_cases: Vec<TestCase> = serde_json::from_str(test_data).unwrap();
+
+    test_cases.iter().for_each(|test| {
+        println!("Running test {}", &test.name);
+        let input = array_bytes::hex2bytes_unchecked(&test.input);
+        let result = alt_bn128_multiplication(&input);
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        let expected = array_bytes::hex2bytes_unchecked(&test.expected);
+        assert_eq!(result, expected);
+    });
+}
+
+#[test]
+#[cfg(not(target_arch = "bpf"))]
+fn alt_bn128_pairing_test() {
+    use serde::Deserialize;
+
+    let test_data = r#"[
+        {
+            "Input": "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "jeff1",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "2eca0c7238bf16e83e7a1e6c5d49540685ff51380f309842a98561558019fc0203d3260361bb8451de5ff5ecd17f010ff22f5c31cdf184e9020b06fa5997db841213d2149b006137fcfb23036606f848d638d576a120ca981b5b1a5f9300b3ee2276cf730cf493cd95d64677bbb75fc42db72513a4c1e387b476d056f80aa75f21ee6226d31426322afcda621464d0611d226783262e21bb3bc86b537e986237096df1f82dff337dd5972e32a8ad43e28a78a96a823ef1cd4debe12b6552ea5f06967a1237ebfeca9aaae0d6d0bab8e28c198c5a339ef8a2407e31cdac516db922160fa257a5fd5b280642ff47b65eca77e626cb685c84fa6d3b6882a283ddd1198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "jeff2",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "0f25929bcb43d5a57391564615c9e70a992b10eafa4db109709649cf48c50dd216da2f5cb6be7a0aa72c440c53c9bbdfec6c36c7d515536431b3a865468acbba2e89718ad33c8bed92e210e81d1853435399a271913a6520736a4729cf0d51eb01a9e2ffa2e92599b68e44de5bcf354fa2642bd4f26b259daa6f7ce3ed57aeb314a9a87b789a58af499b314e13c3d65bede56c07ea2d418d6874857b70763713178fb49a2d6cd347dc58973ff49613a20757d0fcc22079f9abd10c3baee245901b9e027bd5cfc2cb5db82d4dc9677ac795ec500ecd47deee3b5da006d6d049b811d7511c78158de484232fc68daf8a45cf217d1c2fae693ff5871e8752d73b21198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "jeff3",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "2f2ea0b3da1e8ef11914acf8b2e1b32d99df51f5f4f206fc6b947eae860eddb6068134ddb33dc888ef446b648d72338684d678d2eb2371c61a50734d78da4b7225f83c8b6ab9de74e7da488ef02645c5a16a6652c3c71a15dc37fe3a5dcb7cb122acdedd6308e3bb230d226d16a105295f523a8a02bfc5e8bd2da135ac4c245d065bbad92e7c4e31bf3757f1fe7362a63fbfee50e7dc68da116e67d600d9bf6806d302580dc0661002994e7cd3a7f224e7ddc27802777486bf80f40e4ca3cfdb186bac5188a98c45e6016873d107f5cd131f3a3e339d0375e58bd6219347b008122ae2b09e539e152ec5364e7e2204b03d11d3caa038bfc7cd499f8176aacbee1f39e4e4afc4bc74790a4a028aff2c3d2538731fb755edefd8cb48d6ea589b5e283f150794b6736f670d6a1033f9b46c6f5204f50813eb85c8dc4b59db1c5d39140d97ee4d2b36d99bc49974d18ecca3e7ad51011956051b464d9e27d46cc25e0764bb98575bd466d32db7b15f582b2d5c452b36aa394b789366e5e3ca5aabd415794ab061441e51d01e94640b7e3084a07e02c78cf3103c542bc5b298669f211b88da1679b0b64a63b7e0e7bfe52aae524f73a55be7fe70c7e9bfc94b4cf0da1213d2149b006137fcfb23036606f848d638d576a120ca981b5b1a5f9300b3ee2276cf730cf493cd95d64677bbb75fc42db72513a4c1e387b476d056f80aa75f21ee6226d31426322afcda621464d0611d226783262e21bb3bc86b537e986237096df1f82dff337dd5972e32a8ad43e28a78a96a823ef1cd4debe12b6552ea5f",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "jeff4",
+            "Gas": 147000,
+            "NoBenchmark": false
+        },{
+            "Input": "20a754d2071d4d53903e3b31a7e98ad6882d58aec240ef981fdf0a9d22c5926a29c853fcea789887315916bbeb89ca37edb355b4f980c9a12a94f30deeed30211213d2149b006137fcfb23036606f848d638d576a120ca981b5b1a5f9300b3ee2276cf730cf493cd95d64677bbb75fc42db72513a4c1e387b476d056f80aa75f21ee6226d31426322afcda621464d0611d226783262e21bb3bc86b537e986237096df1f82dff337dd5972e32a8ad43e28a78a96a823ef1cd4debe12b6552ea5f1abb4a25eb9379ae96c84fff9f0540abcfc0a0d11aeda02d4f37e4baf74cb0c11073b3ff2cdbb38755f8691ea59e9606696b3ff278acfc098fa8226470d03869217cee0a9ad79a4493b5253e2e4e3a39fc2df38419f230d341f60cb064a0ac290a3d76f140db8418ba512272381446eb73958670f00cf46f1d9e64cba057b53c26f64a8ec70387a13e41430ed3ee4a7db2059cc5fc13c067194bcc0cb49a98552fd72bd9edb657346127da132e5b82ab908f5816c826acb499e22f2412d1a2d70f25929bcb43d5a57391564615c9e70a992b10eafa4db109709649cf48c50dd2198a1f162a73261f112401aa2db79c7dab1533c9935c77290a6ce3b191f2318d198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "jeff5",
+            "Gas": 147000,
+            "NoBenchmark": false
+        },{
+            "Input": "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c103188585e2364128fe25c70558f1560f4f9350baf3959e603cc91486e110936198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "jeff6",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "empty_data",
+            "Gas": 45000,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000000",
+            "Name": "one_point",
+            "Gas": 79000,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "two_point_match_2",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002203e205db4f19b37b60121b83a7333706db86431c6d835849957ed8c3928ad7927dc7234fd11d3e8c36c59277c3e6f149d5cd3cfa9a62aee49f8130962b4b3b9195e8aa5b7827463722b8c153931579d3505566b4edf48d498e185f0509de15204bb53b8977e5f92a0bc372742c4830944a59b4fe6b1c0466e2a6dad122b5d2e030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd31a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "two_point_match_3",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "105456a333e6d636854f987ea7bb713dfd0ae8371a72aea313ae0c32c0bf10160cf031d41b41557f3e7e3ba0c51bebe5da8e6ecd855ec50fc87efcdeac168bcc0476be093a6d2b4bbf907172049874af11e1b6267606e00804d3ff0037ec57fd3010c68cb50161b7d1d96bb71edfec9880171954e56871abf3d93cc94d745fa114c059d74e5b6c4ec14ae5864ebe23a71781d86c29fb8fb6cce94f70d3de7a2101b33461f39d9e887dbb100f170a2345dde3c07e256d1dfa2b657ba5cd030427000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000021a2c3013d2ea92e13c800cde68ef56a294b883f6ac35d25f587c09b1b3c635f7290158a80cd3d66530f74dc94c94adb88f5cdb481acca997b6e60071f08a115f2f997f3dbd66a7afe07fe7862ce239edba9e05c5afff7f8a1259c9733b2dfbb929d1691530ca701b4a106054688728c9972c8512e9789e9567aae23e302ccd75",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "two_point_match_4",
+            "Gas": 113000,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "ten_point_match_1",
+            "Gas": 385000,
+            "NoBenchmark": false
+        },{
+            "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002203e205db4f19b37b60121b83a7333706db86431c6d835849957ed8c3928ad7927dc7234fd11d3e8c36c59277c3e6f149d5cd3cfa9a62aee49f8130962b4b3b9195e8aa5b7827463722b8c153931579d3505566b4edf48d498e185f0509de15204bb53b8977e5f92a0bc372742c4830944a59b4fe6b1c0466e2a6dad122b5d2e030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd31a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002203e205db4f19b37b60121b83a7333706db86431c6d835849957ed8c3928ad7927dc7234fd11d3e8c36c59277c3e6f149d5cd3cfa9a62aee49f8130962b4b3b9195e8aa5b7827463722b8c153931579d3505566b4edf48d498e185f0509de15204bb53b8977e5f92a0bc372742c4830944a59b4fe6b1c0466e2a6dad122b5d2e030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd31a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002203e205db4f19b37b60121b83a7333706db86431c6d835849957ed8c3928ad7927dc7234fd11d3e8c36c59277c3e6f149d5cd3cfa9a62aee49f8130962b4b3b9195e8aa5b7827463722b8c153931579d3505566b4edf48d498e185f0509de15204bb53b8977e5f92a0bc372742c4830944a59b4fe6b1c0466e2a6dad122b5d2e030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd31a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002203e205db4f19b37b60121b83a7333706db86431c6d835849957ed8c3928ad7927dc7234fd11d3e8c36c59277c3e6f149d5cd3cfa9a62aee49f8130962b4b3b9195e8aa5b7827463722b8c153931579d3505566b4edf48d498e185f0509de15204bb53b8977e5f92a0bc372742c4830944a59b4fe6b1c0466e2a6dad122b5d2e030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd31a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002203e205db4f19b37b60121b83a7333706db86431c6d835849957ed8c3928ad7927dc7234fd11d3e8c36c59277c3e6f149d5cd3cfa9a62aee49f8130962b4b3b9195e8aa5b7827463722b8c153931579d3505566b4edf48d498e185f0509de15204bb53b8977e5f92a0bc372742c4830944a59b4fe6b1c0466e2a6dad122b5d2e030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd31a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "ten_point_match_2",
+            "Gas": 385000,
+            "NoBenchmark": false
+        },{
+            "Input": "105456a333e6d636854f987ea7bb713dfd0ae8371a72aea313ae0c32c0bf10160cf031d41b41557f3e7e3ba0c51bebe5da8e6ecd855ec50fc87efcdeac168bcc0476be093a6d2b4bbf907172049874af11e1b6267606e00804d3ff0037ec57fd3010c68cb50161b7d1d96bb71edfec9880171954e56871abf3d93cc94d745fa114c059d74e5b6c4ec14ae5864ebe23a71781d86c29fb8fb6cce94f70d3de7a2101b33461f39d9e887dbb100f170a2345dde3c07e256d1dfa2b657ba5cd030427000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000021a2c3013d2ea92e13c800cde68ef56a294b883f6ac35d25f587c09b1b3c635f7290158a80cd3d66530f74dc94c94adb88f5cdb481acca997b6e60071f08a115f2f997f3dbd66a7afe07fe7862ce239edba9e05c5afff7f8a1259c9733b2dfbb929d1691530ca701b4a106054688728c9972c8512e9789e9567aae23e302ccd75",
+            "Expected": "0000000000000000000000000000000000000000000000000000000000000001",
+            "Name": "ten_point_match_3",
+            "Gas": 113000,
+            "NoBenchmark": false
+        }
+    ]"#;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
+    struct TestCase {
+        input: String,
+        expected: String,
+        name: String,
+    }
+
+    let test_cases: Vec<TestCase> = serde_json::from_str(test_data).unwrap();
+
+    test_cases.iter().for_each(|test| {
+        println!("Running test {}", &test.name);
+        let input = array_bytes::hex2bytes_unchecked(&test.input);
+        let result = alt_bn128_pairing(&input);
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        let expected = array_bytes::hex2bytes_unchecked(&test.expected);
+        assert_eq!(result, expected);
+    });
+}

--- a/sdk/program/src/alt_bn128.rs
+++ b/sdk/program/src/alt_bn128.rs
@@ -14,8 +14,9 @@ use {
 use {
     bigint::U256,
     bn::{pairing, AffineG1, AffineG2, Fq, Fq2, Fr, Group, Gt, G1, G2},
-    consts::*,
 };
+
+use consts::*;
 
 //---- Constants
 
@@ -52,10 +53,10 @@ mod consts {
     const_assert_eq!(ALT_BN128_POINT_SIZE, ALT_BN128_FIELD_SIZE * 2);
 
     /// Internal representation of the EC field (32 bytes).
-    pub(super) type FieldBytes = [u8; ALT_BN128_FIELD_SIZE];
+    pub type FieldBytes = [u8; ALT_BN128_FIELD_SIZE];
 
     /// Internal representation of the EC point (64 bytes).
-    pub(super) type PointBytes = [u8; ALT_BN128_POINT_SIZE];
+    pub type PointBytes = [u8; ALT_BN128_POINT_SIZE];
 }
 
 //---- Custom errors

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate self as solana_program;
 
 pub mod account_info;
+pub mod alt_bn128;
 pub mod borsh;
 pub mod bpf_loader;
 pub mod bpf_loader_deprecated;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -139,6 +139,18 @@ pub mod system_transfer_zero_check {
     solana_sdk::declare_id!("BrTR9hzw4WBGFP65AJMbpAo64DcA3U6jdPSga9fMV5cS");
 }
 
+pub mod alt_bn128_addition_syscall_enabled {
+    solana_sdk::declare_id!("6RvdSWHh8oh72Dp7wMTS2DBkf3fRPtChfNrAo3cZZoXJ");
+}
+
+pub mod alt_bn128_multiplication_syscall_enabled {
+    solana_sdk::declare_id!("6RvdSWHh8oh72Dp7wMTS2DBkf3fRPtChfNrAo3cZZoXJ");
+}
+
+pub mod alt_bn128_pairing_syscall_enabled {
+    solana_sdk::declare_id!("BTW2pSyErTj4BV6KBM9NZ9VBUJVxt7sacNWcf76wtzb2");
+}
+
 pub mod dedupe_config_program_signers {
     solana_sdk::declare_id!("8kEuAshXLsgkUEdcFVLqrjCGGHVWFW99ZZpxvAzzMtBp");
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -140,15 +140,15 @@ pub mod system_transfer_zero_check {
 }
 
 pub mod alt_bn128_addition_syscall_enabled {
-    solana_sdk::declare_id!("6RvdSWHh8oh72Dp7wMTS2DBkf3fRPtChfNrAo3cZZoXJ");
+    solana_sdk::declare_id!("7Ua8mFtahVfA3WCY9LoXDAJJdvJRJHckvSSr1dD8FTWc");
 }
 
 pub mod alt_bn128_multiplication_syscall_enabled {
-    solana_sdk::declare_id!("6RvdSWHh8oh72Dp7wMTS2DBkf3fRPtChfNrAo3cZZoXJ");
+    solana_sdk::declare_id!("7Ua8mFtahVfA3WCY9LoXDAJJdvJRJHckvSSr1dD8FTWc");
 }
 
 pub mod alt_bn128_pairing_syscall_enabled {
-    solana_sdk::declare_id!("BTW2pSyErTj4BV6KBM9NZ9VBUJVxt7sacNWcf76wtzb2");
+    solana_sdk::declare_id!("7Ua8mFtahVfA3WCY9LoXDAJJdvJRJHckvSSr1dD8FTWc");
 }
 
 pub mod dedupe_config_program_signers {

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -181,6 +181,12 @@ pub struct BpfComputeBudget {
     pub sysvar_base_cost: u64,
     /// Number of compute units consumed to call secp256k1_recover
     pub secp256k1_recover_cost: u64,
+    /// Number of compute units consumed to call alt_bn128_addition
+    pub alt_bn128_addition_cost: u64,
+    /// Number of compute units consumed to call alt_bn128_multiplication.
+    pub alt_bn128_multiplication_cost: u64,
+    /// Number of compute units consumed to call alt_bn128_pairing.
+    pub alt_bn128_pairing_cost: u64,
     /// Optional program heap region size, if `None` then loader default
     pub heap_size: Option<usize>,
 }
@@ -207,6 +213,9 @@ impl BpfComputeBudget {
             cpi_bytes_per_unit: 250,        // ~50MB at 200,000 units
             sysvar_base_cost: 100,
             secp256k1_recover_cost: 25_000,
+            alt_bn128_addition_cost: 500,
+            alt_bn128_multiplication_cost: 40_000,
+            alt_bn128_pairing_cost: 200_000,
             heap_size: None,
         }
     }


### PR DESCRIPTION
Obsolete! Use https://github.com/neonlabsorg/solana/pull/43

# BN256 Syscalls Implementation

This merge request implements the bn256 addition, scalar multiplication, and pairing system calls.

I take the existing implementations as a basis:

- SputnikVM: https://github.com/ETCDEVTeam/sputnikvm/blob/master/precompiled/bn128/src/lib.rs
- Go Ethereum: https://github.com/ethereum/go-ethereum/blob/master/crypto/bn256/google/bn256.go
- Input/Output: https://github.com/input-output-hk/chain-libs/blob/d1953fc0a4c1672c58904ac3ffe7772496d6ec79/chain-evm/src/precompiles/bn128.rs

## Features

1. The input parameters are common. All variables transfer as a single byte array, facilitating implementation inside Neon EVM.
1. Added padding with zeros for incoming values by the requirements of Ethereum.
1. The values `alt_bn128_addition_cost`, `alt_bn128_multiplication_cost`, `alt_bn128_pairing_cost` in the `process_instructions.rs` file should be recalculated.

## Known problems

We have an issue with launching `solana-test-validator` at `solana 1.7.9-testnet` branch:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', validator/src/bin/solana-test-validator.rs:294:71
```
I had to check on the current version of Solana with these syscalls added.

## To-do

1. We need to generate identifiers for new features.
1. C tests not done.

## Blockers

- It might make sense to upgrade to a newer branch of Solana instead of `1.7.9-testnet`. But `evm-loader` can make its own versioning requirements.

